### PR TITLE
fix Jabra NoClassDefFoundError when pairing BT headset mid-Zoom session

### DIFF
--- a/zoom/android/proguard.cfg
+++ b/zoom/android/proguard.cfg
@@ -35,6 +35,11 @@
 -dontwarn kotlin.uuid.Uuid
 
 # BlueParrott SDK - Optional Bluetooth headset support
+# The real SDK is not bundled (would push us over the 200MB Play limit).
+# Instead we ship no-op stubs in src/main/java/com/blueparrott/blueparrottsdk/ so
+# the Zoom SDK's jabra.* classes can resolve at runtime. Keep the stubs from R8 —
+# nothing in plugin Java code references them, so without -keep they'd be stripped.
+-keep class com.blueparrott.blueparrottsdk.** { *; }
 -dontwarn com.blueparrott.blueparrottsdk.**
 
 # Jabra SDK - Optional Bluetooth headset support (referenced by mobilertc.aar WebRTC)

--- a/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPHeadset.java
+++ b/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPHeadset.java
@@ -1,0 +1,18 @@
+package com.blueparrott.blueparrottsdk;
+
+// No-op stub. mobilertc.aar references this interface via invokeinterface.
+public interface BPHeadset {
+    boolean connected();
+
+    boolean valuesRead();
+
+    boolean sdkModeEnabled();
+
+    void enableSDKMode();
+
+    void disableSDKMode();
+
+    void connect(int mode);
+
+    void addListener(IBPHeadsetListener listener);
+}

--- a/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPHeadsetListener.java
+++ b/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPHeadsetListener.java
@@ -1,0 +1,44 @@
+package com.blueparrott.blueparrottsdk;
+
+// No-op stub. jabra.a$c extends this and calls super.<method>() via invokespecial,
+// so we need a concrete class with empty method bodies (not abstract).
+public class BPHeadsetListener {
+    public BPHeadsetListener() {
+    }
+
+    public void onConnect() {
+    }
+
+    public void onConnectProgress(int progressCode) {
+    }
+
+    public void onConnectFailure(int errorCode) {
+    }
+
+    public void onValuesRead() {
+    }
+
+    public void onDisconnect() {
+    }
+
+    public void onButtonDown(int buttonId) {
+    }
+
+    public void onButtonUp(int buttonId) {
+    }
+
+    public void onModeUpdate() {
+    }
+
+    public void onModeUpdateFailure(int errorCode) {
+    }
+
+    public void onDoubleTap(int buttonId) {
+    }
+
+    public void onTap(int buttonId) {
+    }
+
+    public void onLongPress(int buttonId) {
+    }
+}

--- a/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPSdk.java
+++ b/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/BPSdk.java
@@ -1,0 +1,50 @@
+package com.blueparrott.blueparrottsdk;
+
+import android.content.Context;
+
+// No-op stub. Zoom's JabraDeviceManager calls BPSdk.getBPHeadset(context) and then
+// invokes methods on the returned BPHeadset without null-checking, so we must
+// return a non-null no-op singleton rather than null.
+public class BPSdk {
+    private static final BPHeadset NO_OP_HEADSET = new NoOpHeadset();
+
+    public static void setRemoteLogging(boolean enabled) {
+    }
+
+    public static BPHeadset getBPHeadset(Context context) {
+        return NO_OP_HEADSET;
+    }
+
+    private static final class NoOpHeadset implements BPHeadset {
+        @Override
+        public boolean connected() {
+            return false;
+        }
+
+        @Override
+        public boolean valuesRead() {
+            return false;
+        }
+
+        @Override
+        public boolean sdkModeEnabled() {
+            return false;
+        }
+
+        @Override
+        public void enableSDKMode() {
+        }
+
+        @Override
+        public void disableSDKMode() {
+        }
+
+        @Override
+        public void connect(int mode) {
+        }
+
+        @Override
+        public void addListener(IBPHeadsetListener listener) {
+        }
+    }
+}

--- a/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/IBPHeadsetListener.java
+++ b/zoom/android/src/main/java/com/blueparrott/blueparrottsdk/IBPHeadsetListener.java
@@ -1,0 +1,36 @@
+package com.blueparrott.blueparrottsdk;
+
+// No-op stub so the Zoom SDK's jabra.* classes can resolve their superinterfaces
+// at runtime without the real BlueParrott SDK being bundled.
+// See: zoom/android/proguard.cfg and the plan in plans/this-is-not-a-dapper-brooks.md
+public interface IBPHeadsetListener {
+    void onConnectProgress(int progressCode);
+
+    void onConnect();
+
+    void onConnectFailure(int errorCode);
+
+    void onDisconnect();
+
+    void onModeUpdate();
+
+    void onModeUpdateFailure(int errorCode);
+
+    void onButtonDown(int buttonId);
+
+    void onButtonUp(int buttonId);
+
+    void onTap(int buttonId);
+
+    void onDoubleTap(int buttonId);
+
+    void onLongPress(int buttonId);
+
+    void onProximityChange(int value);
+
+    void onHeadsetLogChange(String message);
+
+    void onValuesRead();
+
+    void onEnterpriseValuesRead();
+}


### PR DESCRIPTION
mobilertc.aar 6.6.9 ships a JabraDeviceManager (jabra.*) that references com.blueparrott.blueparrottsdk.* classes we don't bundle. When a BT device connects during an active meeting, Zoom's Jabra hook loads jabra.a$a, which triggers resolution of its BlueParrott superinterface -> NoClassDefFoundError. Result: either silent audio-route failure (stays on speaker) or app crash.

Ship minimal no-op stubs for the 4 BlueParrott types Zoom references (BPSdk, BPHeadset, BPHeadsetListener, IBPHeadsetListener). Class loading now succeeds; Zoom's Jabra code path becomes a harmless no-op and normal Android audio routing takes over. BPSdk.getBPHeadset returns a non-null singleton because jabra.a calls addListener on the result without a null check.

Added -keep rule for com.blueparrott.** since nothing in plugin Java source calls the stubs directly and R8 would otherwise strip them.